### PR TITLE
Added MongoDB support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,22 @@ Note that this project is a work in progress. **The release of a functional prot
 
 ## Docker
 
+### Requirements
+* Docker
+* docker-compose
+
+### Instructions
+
 Coming soon...
 
 ## Non-dockerized
+
+### Requirements
+* MongoDB
+* Python3
+* virtualenv
+
+### Instructions
 
 Clone repository
 ```bash
@@ -47,6 +60,11 @@ python setup.py develop
 Set config file environment variable
 ```bash
 export WES_CONFIG="$PWD/config.yaml"
+```
+
+Start MongoDB daemon
+```bash
+sudo service mongod start
 ```
 
 Start service

--- a/app/app.py
+++ b/app/app.py
@@ -26,8 +26,22 @@ try:
 except KeyError:
     sys.exit("Config file corrupt. Execution aborted.")
 
-app.app.config["MONGO_URI"] = "mongodb://localhost:27017/myDatabase"
-mongo = PyMongo(app.app)
+
+# Initialize database
+try:
+    mongo = PyMongo(app.app, uri="mongodb://{host}:{port}/{name}".format(
+        host=config['database']['host'],
+        port=config['database']['port'],
+        name=config['database']['name']
+    ))
+    db = mongo.db[config['database']['name']]
+except KeyError:
+    sys.exit("Config file corrupt. Execution aborted.")
+
+
+# Add database collections
+db_service_info = mongo.db['service-info']
+db_runs = mongo.db['runs']
 
 
 def configure_app(app):

--- a/app/ga4gh/wes/server/controllers.py
+++ b/app/ga4gh/wes/server/controllers.py
@@ -4,7 +4,7 @@ Controllers for the workflow execution service
 """
 
 from connexion import request
-from app import app, config, mongo
+from app import config, db_runs, db_service_info
 
 
 def CancelRun(**kwargs):

--- a/config.yaml
+++ b/config.yaml
@@ -1,14 +1,20 @@
 # General server settings
 server:
-  host: 'localhost'
-  port: 7777
-  debug: True
+    host: 'localhost'
+    port: 7777
+    debug: True
 
-# Location of API specs
+# Location of OpenAPI specs
 openapi:
-  path: 'openapi'
-  yaml_specs: 'ga4gh.wes.0.3.0.openapi.yaml'
+    path: 'openapi'
+    yaml_specs: 'ga4gh.wes.0.3.0.openapi.yaml'
+
+# Database settings
+database:
+    host: 'localhost'
+    port: 27017
+    name: wes-elixir-db
 
 # Endpoint parameters
 api_endpoints:
-  default_page_size: 100
+    default_page_size: 100


### PR DESCRIPTION
Added MongoDB support via Flask-PyMongo. Host, port and database name can be set in the config file. Collections for `/runs` and `/service-info` endpoints were added and can be imported where required.

The support is minimal: No read/write protection was added and the database-related code should probably be packaged into a class in a separate module at some point.

Closes #3