### PR TITLE
Fixed serialization/deserialization issues

### DIFF
--- a/wes_elixir/ga4gh/wes/utils_bg_tasks.py
+++ b/wes_elixir/ga4gh/wes/utils_bg_tasks.py
@@ -51,6 +51,9 @@ def __process_cwl_logs(
 
         line = line.rstrip()
 
+        # Replace single quote characters to avoid `literal_eval()` errors
+        line = line.replace("'", '"')
+
         # Handle special cases
         lines = __handle_cwl_tes_log_irregularities(line)
         for line in lines:

--- a/wes_elixir/ga4gh/wes/utils_runs.py
+++ b/wes_elixir/ga4gh/wes/utils_runs.py
@@ -6,6 +6,7 @@ import os
 import re
 import shutil
 import subprocess
+import string  # noqa: F401
 
 from celery import (Celery, uuid)
 from json import (decoder, loads)
@@ -684,12 +685,12 @@ def __run_workflow(
     # ]
     # TEST CASE FOR EXECUTOR ERROR
     # command_list = [
-    #     '/bin/false'
+    #     '/bin/false',
     # ]
     # TEST CASE FOR SLOW COMPLETION WITH ARGUMENT (NO STDOUT/STDERR)
     # command_list = [
     #     'sleep',
-    #     '30'
+    #     '30',
     # ]
 
     # Execute command as background task

--- a/wes_elixir/tasks/celery_task_monitor.py
+++ b/wes_elixir/tasks/celery_task_monitor.py
@@ -95,14 +95,14 @@ class TaskMonitor():
             except Exception as e:
                 logger.exception(
                     (
-                        'Unknown error in task monitor occurred. Execution '
-                        'aborted. Original error message: {type}: {msg}'
+                        'Unknown error in task monitor occurred. Original '
+                        'error message: {type}: {msg}'
                     ).format(
                         type=type(e).__name__,
                         msg=e,
                     )
                 )
-                raise SystemExit
+                pass
 
             # Sleep for specified interval
             sleep(self.timeout)
@@ -141,14 +141,14 @@ class TaskMonitor():
         except Exception as e:
             logger.exception(
                 (
-                    "Field 'kwargs' in event message malformed. Execution "
-                    'aborted. Original error message: {type}: {msg}'
+                    "Field 'kwargs' in event message malformed. Original "
+                    'error message: {type}: {msg}'
                 ).format(
                     type=type(e).__name__,
                     msg=e,
                 )
             )
-            raise SystemExit
+            pass
 
         # Build command
         if 'command_list' in kwargs:
@@ -280,14 +280,14 @@ class TaskMonitor():
         except Exception as e:
             logger.exception(
                 (
-                    "Field 'result' in event message malformed. Execution "
-                    'aborted. Original error message: {type}: {msg}'
+                    "Field 'result' in event message malformed. Original "
+                    'error message: {type}: {msg}'
                 ).format(
                     type=type(e).__name__,
                     msg=e,
                 )
             )
-            raise SystemExit
+            pass
 
         # Create dictionary for internal parameters
         internal = dict()


### PR DESCRIPTION
**Details**

Replacing single with double quotes in each STDERR/STDOUT line seems to prevent those issues  from arising. Furthermore, errors happening during execution are now only written to the log, but do not raise a `SystemExit` exception. This previously led to only the task monitor daemon shutting down, making the service unaware of state changes. 

**Testing**

The hashsplitter workflow completed without issues. Several forced EXECUTOR_ERRORs and SYSTEM_ERRORs were also processed as expected.

**Closing issues**

Closes #50 