### PR TITLE
Add my name under contributors

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -8,6 +8,7 @@
 ## Other contributors (in alphabetical order)
 
 * [Shubham Kapoor](https://github.com/shukapoo)
+* [Risto Laurikainen](https://github.com/rlaurika)
 * [Susheel Varma](https://github.com/susheel)
 * [Kevin Sayers](https://github.com/KevinSayers)
 * [Jaroslaw Surkont](https://github.com/jsurkont)


### PR DESCRIPTION
**Details**

Since the Kubernetes templates under deployment are merged to dev, add
my name in contributors.md.

**Closing issues**

Related to #81 and #88 