### PR TITLE
Set queue and concurrency options on Celery worker

### DIFF
--- a/deployment/common/wes/wes-celery-deployment.yaml
+++ b/deployment/common/wes/wes-celery-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         image: weselixir/elixir-wes-app:rc1
         workingDir: '/app/wes_elixir'
         command: [ 'celery' ]
-        args: [ 'worker', '-A', 'celery_worker', '-E', '--loglevel=info' ]
+        args: [ 'worker', '-A', 'celery_worker', '-E', '--loglevel=info', '-c', '1', '-Q', 'celery' ]
         env:
         - name: MONGO_HOST
           value: mongodb
@@ -53,7 +53,7 @@ spec:
             cpu: "300m"
           limits:
             memory: "8Gi"
-            cpu: "2"
+            cpu: "1"
         volumeMounts:
         - mountPath: /data
           name: wes-volume


### PR DESCRIPTION
**Details**

Initially we want to have a concurrency of 1 for each Celery worker
instance. Set this in the deployment YAML as additional argument. Also
add a queue option as a placeholder and set the value to "celery".

**Testing**

Tested by redeploying the Celery worker deployment with the new options.

**Closing issues**

Related to #81 