### PR TITLE
Changes for all hands meeting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,19 +31,21 @@ RUN wget https://www.python.org/ftp/python/3.6.0/Python-3.6.0.tar.xz \
   && cd .. \
   && python -m pip install --upgrade pip setuptools wheel virtualenv
 
-## Copy app files
-COPY ./ /app
+## Copy app requirements
+COPY ./requirements.txt /app
 
-## Install dependencies
+## Install app dependencies
 RUN cd /app \
   && pip install -r requirements.txt \
-  && python setup.py develop \
   && cd /app/src/cwl-tes \
   && python setup.py develop \
-  && cd /app/src/cwltool \
-  && python setup.py develop \
-  && cd /app/src/py-tes \
-  && python setup.py develop \
+  && cd /app
+
+## Copy remaining app files
+COPY ./ .
+
+## Install app
+RUN python setup.py develop \
   && cd /
 
 ## Copy FTP server credentials

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,21 +31,25 @@ RUN wget https://www.python.org/ftp/python/3.6.0/Python-3.6.0.tar.xz \
   && cd .. \
   && python -m pip install --upgrade pip setuptools wheel virtualenv
 
+## Set working directory
+WORKDIR /app
+
 ## Copy app requirements
-COPY ./requirements.txt /app
+COPY ./requirements.txt /app/requirements.txt
 
 ## Install app dependencies
 RUN cd /app \
   && pip install -r requirements.txt \
   && cd /app/src/cwl-tes \
   && python setup.py develop \
-  && cd /app
+  && cd /
 
 ## Copy remaining app files
-COPY ./ .
+COPY ./ /app
 
 ## Install app
-RUN python setup.py develop \
+RUN cd /app \
+  && python setup.py develop \
   && cd /
 
 ## Copy FTP server credentials

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,6 +12,7 @@ services:
     command: bash -c "cd /app/wes_elixir; celery worker -A celery_worker -E --loglevel=info"
     volumes:
       - ../data:/data
+      - /wes/vol:/tmp
 
   wes-elixir:
     image: wes-elixir:latest

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,8 +15,8 @@ click==6.7
 clickclick==1.2.2
 connexion==1.5.2
 cryptography==2.3.1
--e git+https://github.com/uniqueg/cwl-tes-temp.git@b46755b410fae8770ee54ddb0eb8e30f7ac075d7#egg=cwl-tes
--e git+https://github.com/common-workflow-language/cwltool.git@91e9e9f655fb149a2d3344a69883e147e94b2f50#egg=cwltool
+-e git+https://github.com/uniqueg/cwl-tes-temp.git@e37090e00f2573e84becec30f0ade9c5003820b3#egg=cwl-tes
+cwltool==1.0.20181201184214
 decorator==4.3.0
 Flask==1.0.2
 Flask-Cors==3.0.6
@@ -36,12 +36,12 @@ lockfile==0.12.2
 lxml==4.2.5
 MarkupSafe==1.0
 mccabe==0.6.1
-mistune==0.7.4
+mistune==0.8.4
 mypy-extensions==0.4.1
 networkx==2.2
 prov==1.5.1
 psutil==5.4.7
--e git+https://github.com/ohsu-comp-bio/py-tes.git@199604418f06d72fd5fd200ed67f3cc223d4544a#egg=py-tes
+py-tes==0.3.0
 pycparser==2.19
 PyJWT==1.6.4
 pylint==2.1.1
@@ -55,7 +55,7 @@ rdflib-jsonld==0.4.0
 requests==2.20.0
 ruamel.yaml==0.15.51
 scandir==1.9.0
-schema-salad==2.7.20180905124720
+schema-salad==3.0.20181129082112
 shellescape==3.4.1
 six==1.11.0
 subprocess32==3.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ inflection==0.3.1
 isodate==0.6.0
 isort==4.3.4
 itsdangerous==0.24
-Jinja2==2.10
+Jinja2==2.10.1
 jsonschema==2.6.0
 kombu==4.2.1
 lazy-object-proxy==1.3.1
@@ -49,7 +49,7 @@ pymongo==3.7.1
 pyparsing==2.2.1
 python-dateutil==2.6.1
 pytz==2018.5
-PyYAML==3.13
+PyYAML==4.2b1
 rdflib==4.2.2
 rdflib-jsonld==0.4.0
 requests==2.20.0
@@ -63,7 +63,7 @@ swagger-spec-validator==2.3.1
 typed-ast==1.1.0
 typing==3.6.6
 typing-extensions==3.6.5
-urllib3==1.23
+urllib3==1.24.2
 vine==1.1.4
 Werkzeug==0.14.1
 wrapt==1.10.11

--- a/wes_elixir/config/app_config.yaml
+++ b/wes_elixir/config/app_config.yaml
@@ -15,14 +15,15 @@ security:
         algorithm: RS256
         public_key: |-
             -----BEGIN PUBLIC KEY-----
-            MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyUt09EkKGW30jpggX1PY
-            qrxuUw4Fo7a/uMiNvmy8CwBLfo+BgaI35Qi+ke/Dz9784CmNXjlIzNPFq+DUi+8p
-            BDGAJ5hznfEoQI2TDzdiG7uIART4AEpLo9xCKrL1al37jrDmvgk98gbumnHsWKQb
-            7KFRKHpIBvNVQ6v+z3nOQZ+fl1552S750ZSIfTXWXqlZohLVE9K8JwsM9i9z7h5E
-            BU2cJkxPbFoZEs6zGMFEOohiAA99Nm7cW/3m3dCn+Nm5TJadEt/xR08b2GXhcg+t
-            AC7qoBthpDFnUOrLbwvNWQIyE+Mch+z4+5LVTfElOGRem2tZaqYcMG/mY6EBra8p
-            UwIDAQAB
+            MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuVHPfUHVEzpgOnDNi3e2
+            pVsbK1hsINsTy/1mMT7sxDyP+1eQSjzYsGSUJ3GHq9LhiVndpwV8y7Enjdj0pury
+            wtwk/D8z9IIN36RJAh1yhFfbyhLPEZlCDdzxas5Dku9k0GrxQuV6i30Mid8OgRQ2
+            q3pmsks414Afy6xugC6u3inyjLzLPrhR0oRPTGdNMXJbGw4sVTjnh5AzTgX+GrQW
+            BHSjI7rMTcvqbbl7M8OOhE3MQ/gfVLXwmwSIoKHODC0RO+XnVhqd7Qf0teS1JiIL
+            KYLl5FS/7Uy2ClVrAYd2T6X9DIr/JlpRkwSD899pq6PR9nhKguipJE0qUXxamdY9
+            nwIDAQAB
             -----END PUBLIC KEY-----
+
         header_name: Authorization
         token_prefix: Bearer
         identity_claim: sub
@@ -56,7 +57,7 @@ celery:
 # OpenAPI specs
 api:
     specs:
-        - path: '20181010.be85140.workflow_execution_service.swagger.yaml'
+        - path: '20181010.be85140.workflow_execution_service.swagger.modified.yaml'
           strict_validation: True
           validate_responses: True
           swagger_ui: True


### PR DESCRIPTION
**Details**

Running the RD demo workflow for the ELIXIR All Hands Meeting in Lissabon in June 2019 required some minor changes:
- Updated `requirements.txt` to use stable releases for `cwltool` and `py-tes` packages; updated forked version of `cwl-tes` package
- Updated `Dockerfile` according; also refactored to reduce build time when requirements are not updated
- Mounted additional storage space `/wes/vol` in `/tmp` directory inside app container; this is because `cwltool` or `cwl-tes` currently (and needlessly) downloads all input/output files, leading to fast accumulation of data; a cron job on the dev VM at the CSC in Finland (http://193.167.189.73:7777/ga4gh/wes/v1/ui) deletes any data in `/wes/vol` frequently
- Replaced ELIXIR AAI public key