### PR TITLE
fix: cwl-tes and typing-extensions version conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,7 @@ subprocess32==3.5.2
 swagger-spec-validator==2.3.1
 typed-ast==1.1.0
 typing==3.6.6
-typing-extensions==3.6.5
+typing-extensions==3.7.4
 urllib3==1.24.2
 vine==1.1.4
 Werkzeug==0.15.3


### PR DESCRIPTION
**Details**

Updated `typing-extensions` package to version `3.7.4`, as is required by the currently used version of `cwl-tes`.