### PR TITLE
Add missing entries for netrc file

### DIFF
--- a/deployment/templates/wes/wes-deployment.yaml
+++ b/deployment/templates/wes/wes-deployment.yaml
@@ -91,3 +91,6 @@ spec:
       - name: wes-netrc-secret # TODO
         secret:
           secretName: netrc
+          items:
+          - key: netrc
+            path: .netrc


### PR DESCRIPTION
**Details**

This is a small fix for #136. Each individual file we want to mount using the subPath feature must be declared individually as explained here:  https://dev.to/joshduffney/kubernetes-using-configmap-subpaths-to-mount-files-3a1i

**Closing issues**

This closes #136
