### PR TITLE
Add missing entries for app_config.yaml file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,5 +45,7 @@ RUN cd /app \
   && python setup.py develop \
   && cd /
 
+RUN chmod g+w /app/wes_elixir/api/
+
 ## Copy FTP server credentials
 COPY .netrc /root

--- a/deployment/templates/wes/wes-deployment.yaml
+++ b/deployment/templates/wes/wes-deployment.yaml
@@ -88,6 +88,9 @@ spec:
         configMap:
           defaultMode: 420
           name: {{ .Values.wes.appName }}-config
+          items:
+          - key: app_config.yaml
+            path: app_config.yaml
       - name: wes-netrc-secret # TODO
         secret:
           secretName: netrc


### PR DESCRIPTION

**Details**

This fixes #138

**Documentation**

In one file, a similar fix for #136 (`.netrc`) is applied for `app-config.yaml`. Also the permission of the folder `/app/wes_elixir/api/` is changed. The permission change is to add write permission to the `root` group.

**Closing issues**

closes #138 

**Credit**

