### PR TITLE
Fix faulty dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ click==6.7
 clickclick==1.2.2
 connexion==1.5.2
 cryptography==2.3.1
--e git+https://github.com/ohsu-comp-bio/cwl-tes.git@62840435c5b22ac7b3ad1724047d811f72dd372d#egg=cwl-tes
+-e git+https://github.com/ohsu-comp-bio/cwl-tes.git@0e15fae512f9228ac089d569f440a51107654074#egg=cwl-tes
 cwltool==1.0.20181217162649
 decorator==4.3.0
 Flask==1.0.2
@@ -35,7 +35,7 @@ kombu==4.2.1
 lazy-object-proxy==1.3.1
 lockfile==0.12.2
 lxml==4.2.5
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 mccabe==0.6.1
 mistune==0.8.4
 mypy-extensions==0.4.1


### PR DESCRIPTION
- downgrade `cwl-tes` version because later versions require considerable changes in service in order to work; now locked to [latest compatible commit](https://github.com/ohsu-comp-bio/cwl-tes/commit/0e15fae512f9228ac089d569f440a51107654074)
- upgrade `MarkupSafe` version because of [issue](https://github.com/pallets/markupsafe/issues/57#issuecomment-597105876) in previously locked version `1.0`