### PR TITLE
Allow modified specs to be written

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ COPY ./ /app
 RUN cd /app \
   && python setup.py develop \
   && cd / \
-  && chmod g+w /app/cwl_wes/api/
+  && chmod g+w /app/wes_elixir/api/
 
 ## Copy FTP server credentials
 COPY .netrc /root

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,10 +40,11 @@ RUN cd /app \
 ## Copy remaining app files
 COPY ./ /app
 
-## Install app
+## Install app & set write permissions for specs directory
 RUN cd /app \
   && python setup.py develop \
-  && cd /
+  && cd / \
+  && chmod g+w /app/cwl_wes/api/
 
 ## Copy FTP server credentials
 COPY .netrc /root

--- a/contributors.md
+++ b/contributors.md
@@ -9,6 +9,7 @@
 
 * [Marius Dieckmann](https://github.com/MariusDieckmann)
 * [Susanne Domke](https://github.com/suedomke)
+* [Alvaro Gonzalez](https://github.com/lvarin)
 * [Shubham Kapoor](https://github.com/shukapoo)
 * [Yacine Khettab](https://github.com/djixyacine)
 * [Risto Laurikainen](https://github.com/rlaurika)


### PR DESCRIPTION
When authorization is required (i.e., when app option `authorization_required` is set to `True`), security definitions are added to the WES API specs in order to support log in via Swagger UI. However, when deploying via the Kubernetes/OpenShift deployment instructions in `deployment/`, write permissions are not set for the volume to which the modified specs are supposed to be written, leading to a failed installation.

This PR fixes this issue by adding a directive to the `Dockerfile` that sets write permissions for the destination directory.

Done by @lvarin