### PR TITLE
Add support for 'aud' claim

### DIFF
--- a/cwl_wes/config/app_config.yaml
+++ b/cwl_wes/config/app_config.yaml
@@ -9,7 +9,7 @@ server:
 
 # Security settings
 security:
-    authorization_required: True
+    authorization_required: False
     jwt:
         add_key_to_claims: True
         algorithms:

--- a/cwl_wes/config/app_config.yaml
+++ b/cwl_wes/config/app_config.yaml
@@ -9,10 +9,13 @@ server:
 
 # Security settings
 security:
-    authorization_required: False
+    authorization_required: True
     jwt:
+        add_key_to_claims: True
         algorithms:
           - RS256
+        allow_expired: False
+        audience: null  # list of allowed audiences or 'null' (do not validate audience)
         claim_identity: sub
         claim_issuer: iss
         claim_key_id: kid
@@ -21,7 +24,7 @@ security:
         validation_methods:
           - userinfo
           - public_key
-        validation_checks: any  # 'any' or 'all'
+        validation_checks: all  # 'any' or 'all'
 
 # Database settings
 database:

--- a/cwl_wes/ga4gh/wes/endpoints/run_workflow.py
+++ b/cwl_wes/ga4gh/wes/endpoints/run_workflow.py
@@ -462,15 +462,12 @@ def __run_workflow(
     ]
 
     # Add authorization parameters
-    if 'token' in kwargs:
+    if 'jwt' in kwargs \
+            and 'claims' in kwargs \
+            and 'public_key' in kwargs['claims']:
         auth_params = [
-            '--token-public-key', get_conf(
-                config,
-                'security',
-                'jwt',
-                'public_key'
-            ).encode('unicode_escape').decode('utf-8'),
-            '--token', kwargs['token'],
+            '--token-public-key', kwargs['claims']['public_key'],
+            '--token', kwargs['jwt'],
         ]
         command_list[2:2] = auth_params
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ click==6.7
 clickclick==1.2.2
 connexion==1.5.2
 cryptography==2.3.1
--e git+https://github.com/ohsu-comp-bio/cwl-tes.git@0e15fae512f9228ac089d569f440a51107654074#egg=cwl-tes
+-e git+https://github.com/uniqueg/cwl-tes.git@57a193cabab2444bc9b661f83011837bd5ed571a#egg=cwl-tes
 cwltool==1.0.20181217162649
 decorator==4.3.0
 Flask==1.0.2


### PR DESCRIPTION
- Allowed/trusted audience can be configured
- Audience verification can be switched off
- Token and public key propagated to cwl-tes
- Requirement for 'kid' header claim lifted
- Audience verification switched off in cwl-tes fork
- `cwl-tes` source replaced with updated fork

Closes #150