### PR TITLE
Create HOME directory in /tmp/user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ LABEL maintainer.license="https://spdx.org/licenses/Apache-2.0"
 # Python UserID workaround for OpenShift/K8S
 ENV LOGNAME=ipython
 ENV USER=ipython
+ENV HOME=/tmp/user
 
 # Install general dependencies
 RUN apt-get update && apt-get install -y nodejs openssl git build-essential python3-dev
@@ -35,7 +36,8 @@ RUN cd /app \
   && pip install -r requirements.txt \
   && cd /app/src/cwl-tes \
   && python setup.py develop \
-  && cd /
+  && cd / \
+  && mkdir -p /tmp/user
 
 ## Copy remaining app files
 COPY ./ /app
@@ -44,7 +46,6 @@ COPY ./ /app
 RUN cd /app \
   && python setup.py develop \
   && cd / \
-  && chmod g+w /app/cwl_wes/api/
+  && chmod g+w /app/cwl_wes/api/ \
+  && chmod g+w -R /tmp/user
 
-## Copy FTP server credentials
-COPY .netrc /root

--- a/deployment/templates/wes/celery-deployment.yaml
+++ b/deployment/templates/wes/celery-deployment.yaml
@@ -60,7 +60,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: wes-volume
-        - mountPath: /.netrc
+        - mountPath: /tmp/user/.netrc
           subPath: .netrc
           name: wes-netrc-secret
       volumes:

--- a/deployment/templates/wes/wes-deployment.yaml
+++ b/deployment/templates/wes/wes-deployment.yaml
@@ -75,7 +75,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: wes-volume
-        - mountPath: /.netrc
+        - mountPath: /tmp/user/.netrc
           subPath: .netrc
           name: wes-netrc-secret
       volumes:


### PR DESCRIPTION
Create HOME directory in `/tmp/user`.  Mount `.netrc` in the newly created HOME. The chmod is a workaround, as the installation of a module is done using root.

**Details**

In Openshift, containers are run using a random user. This user belongs to the `root` group. The idea of this change is to create a directory in `/tmp`, and give write permissions to the `root` group. Then the two deployments that mount `.netrc`are changed to reflect this change.
There are other ways to do this, but it seems this approach is the simplest and most resilient.

**Testing**

A workflow has to be launched. Before we could see errors in the log files created in `.cache` and the FTP upload fails due to lack of credentials.

**Closing issues**

closes #140