### PR TITLE
All TES calls use py-tes and forward token

### DIFF
--- a/cwl_wes/config/app_config.yaml
+++ b/cwl_wes/config/app_config.yaml
@@ -93,6 +93,4 @@ service_info:
 tes:
     url: 'https://csc-tesk.c03.k8s-popup.csc.fi/'
     timeout: 5
-    get_logs:
-        url_root: 'v1/tasks/'
-        query_params: '?view=FULL'
+    status_query_params: 'FULL'

--- a/cwl_wes/database/db_utils.py
+++ b/cwl_wes/database/db_utils.py
@@ -78,7 +78,7 @@ def update_tes_task_state(
 def append_to_tes_task_logs(
     collection: Collection,
     task_id: str,
-    tes_log: str
+    tes_log: Mapping,
 ) -> Optional[Mapping[Any, Any]]:
     """Appends task log to TES task logs and returns updated document."""
     return collection.find_one_and_update(

--- a/cwl_wes/ga4gh/wes/endpoints/cancel_run.py
+++ b/cwl_wes/ga4gh/wes/endpoints/cancel_run.py
@@ -82,6 +82,7 @@ def cancel_run(
             {
                 'run_id': run_id,
                 'task_id': document['task_id'],
+                'token': kwargs.get('jwt'),
             },
             task_id=task_id,
             soft_time_limit=timeout_duration,

--- a/cwl_wes/ga4gh/wes/endpoints/run_workflow.py
+++ b/cwl_wes/ga4gh/wes/endpoints/run_workflow.py
@@ -509,6 +509,7 @@ def __run_workflow(
         {
             'command_list': command_list,
             'tmp_dir': tmp_dir,
+            'token': kwargs.get('jwt'),
         },
         task_id=task_id,
         soft_time_limit=timeout_duration,

--- a/cwl_wes/tasks/register_celery.py
+++ b/cwl_wes/tasks/register_celery.py
@@ -27,10 +27,10 @@ def register_task_service(app: Flask) -> None:
             tes_config={
                 'url':
                     app.config['tes']['url'],
-                'logs_endpoint_root':
-                    app.config['tes']['get_logs']['url_root'],
-                'logs_endpoint_query_params':
-                    app.config['tes']['get_logs']['query_params'],
+                'query_params':
+                    app.config['tes']['status_query_params'],
+                'timeout':
+                    app.config['tes']['timeout']
             },
             timeout=app.config['celery']['monitor']['timeout'],
             authorization=app.config['security']['authorization_required'],

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,7 +58,7 @@ ruamel.yaml==0.15.51
 scandir==1.9.0
 schema-salad==3.0.20181129082112
 shellescape==3.4.1
-six==1.11.0
+six==1.14.0
 subprocess32==3.5.2
 swagger-spec-validator==2.3.1
 typed-ast==1.1.0


### PR DESCRIPTION
- Canceling tasks and getting task logs from TES now relies on the [`py-tes`](https://github.com/ohsu-comp-bio/py-tes) client, just like running workflows via [`cwl-tes`](https://github.com/ohsu-comp-bio/cwl-tes). If available, access tokens are attached to every call. Client expects TES specs version 0.4.0.
- Task logs are now stored as objects in the database, not as JSON strings. If task logs cannot be obtained, an empty entry is added. Currently there is no way for the user to retry updating missing task logs (this is tricky territory: while it would be easy to have a call to `GET /runs/{id}` do fresh calls to TES, this is relatively expensive and _usually_ unnecessary; plus it might be that the record becomes unavailable or - worse - changes in the meantime).
- Minor refactoring of TES-related options.

Closes #154 