### PR TITLE
ENH: Allow uploading workflow attachments.

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -19,6 +19,7 @@
 * [Jaroslaw Surkont](https://github.com/jsurkont)
 * [Marco Tangaro](https://github.com/mtangaro)
 * [Juha Törnroos](https://github.com/juhtornr)
+* [Joris Vankerschaver](https://github.com/jvkersch)
 * [Susheel Varma](https://github.com/susheel)
 
 ## Acknowledgements

--- a/cwl_wes/ga4gh/wes/endpoints/run_workflow.py
+++ b/cwl_wes/ga4gh/wes/endpoints/run_workflow.py
@@ -14,6 +14,7 @@ from random import choice
 from typing import Dict
 from yaml import dump
 from werkzeug.datastructures import ImmutableMultiDict
+from werkzeug.utils import secure_filename
 
 from flask import request
 
@@ -56,6 +57,14 @@ def run_workflow(
 
     response = {'run_id': document['run_id']}
     return response
+
+
+def __secure_join(basedir: str, fname: str) -> str:
+    fname = secure_filename(fname)
+    if not fname:
+        # Replace by a random filename
+        fname = uuid()
+    return os.path.join(basedir, fname)
 
 
 def __immutable_multi_dict_to_nested_dict(
@@ -368,13 +377,13 @@ def __process_workflow_attachments(data: Dict) -> Dict:
         if len(workflow_attachments) > 0:
             # Save workflow attachments to workflow directory.
             for attachment in workflow_attachments:
-                path = os.path.join(workflow_dir, attachment.filename)
+                path = __secure_join(workflow_dir, attachment.filename)
                 with open(path, "wb") as dest:
                     shutil.copyfileobj(attachment.stream, dest)
 
             # Adjust workflow_url to point to workflow directory.
             req_data = data['api']['request']
-            workflow_url = os.path.join(workflow_dir, req_data['workflow_url'])
+            workflow_url = __secure_join(workflow_dir, req_data['workflow_url'])
             if os.path.exists(workflow_url):
                 req_data['workflow_url'] = workflow_url
 

--- a/cwl_wes/ga4gh/wes/endpoints/run_workflow.py
+++ b/cwl_wes/ga4gh/wes/endpoints/run_workflow.py
@@ -15,6 +15,8 @@ from typing import Dict
 from yaml import dump
 from werkzeug.datastructures import ImmutableMultiDict
 
+from flask import request
+
 from cwl_wes.config.config_parser import get_conf
 from cwl_wes.errors.errors import BadRequest
 from cwl_wes.tasks.tasks.run_workflow import task__run_workflow
@@ -355,8 +357,26 @@ def __process_workflow_attachments(data: Dict) -> Dict:
             cwl_path
         )
 
-    # Else assume value of 'workflow_url' represents file on local file system
+    # Else assume value of 'workflow_url' represents file on local file system,
+    # or a file that was shipped to the server as a workflow attachment.
     else:
+        # Workflow attachments are grabbed directly from the Flask request
+        # object rather than letting connexion parse them, since current
+        # versions of connexion have a bug that prevents multiple file uploads
+        # with the same name (https://github.com/zalando/connexion/issues/992).
+        workflow_attachments = request.files.getlist("workflow_attachment")
+        if len(workflow_attachments) > 0:
+            # Save workflow attachments to workflow directory.
+            for attachment in workflow_attachments:
+                path = os.path.join(workflow_dir, attachment.filename)
+                with open(path, "wb") as dest:
+                    shutil.copyfileobj(attachment.stream, dest)
+
+            # Adjust workflow_url to point to workflow directory.
+            req_data = data['api']['request']
+            workflow_url = os.path.join(workflow_dir, req_data['workflow_url'])
+            if os.path.exists(workflow_url):
+                req_data['workflow_url'] = workflow_url
 
         # Set main CWL workflow file path
         data['internal']['cwl_path'] = os.path.abspath(


### PR DESCRIPTION
This is a port of an earlier PR (https://github.com/elixir-cloud-aai/proWES/pull/9) to proWES. The commits here are unchanged from the earlier PR (with the exception of changing `pro_wes` to `cwl_wes`).

Addresses #6

Original PR description, applicable here as well:

**Details**

This is a small enhancement to allow for workflows to be submitted with workflow attachments. Workflow attachments are files that are uploaded with the POST request to run a workflow, and can contain the primary workflow, tools required to run the workflow, or input files needed to run the workflow.

The current implementation simply looks for attached files, and persists those to the `workflow_dir`. From there on, `cwl-tes` can be used to upload them to the remote storage when handling the TES request.

I did not add any tests but would be glad to do so, if necessary. The command that I use for smoke testing is
```
curl -X POST \
    --header 'Content-Type: multipart/form-data' \
    --header 'Accept: application/json' \
    -F workflow_params='{"input_file": {"class": "File", "location": "README.txt"}}' \
    -F workflow_type=CWL \
    -F workflow_type_version=v1.0 \
    -F workflow_url=cat-numbered.cwl \
    -F workflow_attachment="@cat-numbered.cwl" \
    -F workflow_attachment="@README.txt" \
    'http://localhost:8080/ga4gh/wes/v1/runs'
```
where `cat-numbered.cwl` simply runs an external tool on the input data, and `README.txt` is any random text file:
```
#!/usr/bin/env cwl-runner

cwlVersion: v1.0
class: CommandLineTool
baseCommand: ["cat", "-n"]
inputs:
  input_file:
    type: File
    inputBinding:
      position: 1
outputs:
  result:
    type: stdout

stdout: output.txt
```