### PR TITLE
build: add script to generate ConfigMap

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -16,6 +16,21 @@ an external value file, then execute:
 helm install <deployment-name> . -f <values-yaml>
 ```
 
+## Change application configuration
+
+It is possible to change the default configuration of the application by using a config map. In order to do so, a script is provided `utils/generate_configuration_map.sh`:
+
+```bash
+oc login (...)
+utils/generate_configuration_map.sh
+```
+
+By default it expects the current default configuration to be at `cwl_wes/config/app_config.yaml`, and the definition of the config map at `deployment/templates/wes/app-config.json`. It can be changed by:
+
+```bash
+utils/generate_configuration_map.sh <APP_CONFIG> [CONFIG_MAP_DEFINITION]
+```
+
 ## Autocert
 
 The helm chart utilizes scheduled TLS certificate fetching from [Let's

--- a/deployment/templates/wes/app-config.json
+++ b/deployment/templates/wes/app-config.json
@@ -1,7 +1,7 @@
 {
   "apiVersion": "v1",
   "data": {
-    "app_config.yaml": "# General server/service settings\nserver:\n    debug: True\n\n# Security settings\nsecurity:\n    authorization_required: {{ .Values.authorization_required }}\n\n# Storage\nstorage:\n    permanent_dir: {{ .Values.storage.permanent_dir | quote }}\n    tmp_dir: {{ .Values.storage.tmp_dir | quote }}\n    remote_storage_url: {{ .Values.storage.remote_storage_url | quote }}\n\n# WES service info settings\nservice_info:\n    contact_info: {{ .Values.service_info.contact_info | quote }}\n    auth_instructions_url: {{ .Values.service_info.auth_instructions_url | quote }}\n    tags:\n        known_tes_endpoints: {{ .Values.service_info.tags.known_tes_endpoints | quote }}\n\n# TES server\ntes:\n    url: '{{ .Values.tes.url }}'\n"
+    "app_config.yaml": "# General server/service settings"
   },
   "kind": "ConfigMap",
   "metadata": {

--- a/deployment/templates/wes/app-config.json
+++ b/deployment/templates/wes/app-config.json
@@ -1,0 +1,10 @@
+{
+  "apiVersion": "v1",
+  "data": {
+    "app_config.yaml": "# General server/service settings\nserver:\n    debug: True\n\n# Security settings\nsecurity:\n    authorization_required: {{ .Values.authorization_required }}\n\n# Storage\nstorage:\n    permanent_dir: {{ .Values.storage.permanent_dir | quote }}\n    tmp_dir: {{ .Values.storage.tmp_dir | quote }}\n    remote_storage_url: {{ .Values.storage.remote_storage_url | quote }}\n\n# WES service info settings\nservice_info:\n    contact_info: {{ .Values.service_info.contact_info | quote }}\n    auth_instructions_url: {{ .Values.service_info.auth_instructions_url | quote }}\n    tags:\n        known_tes_endpoints: {{ .Values.service_info.tags.known_tes_endpoints | quote }}\n\n# TES server\ntes:\n    url: '{{ .Values.tes.url }}'\n"
+  },
+  "kind": "ConfigMap",
+  "metadata": {
+    "name": "app-config"
+  }
+}

--- a/deployment/templates/wes/wes-deployment.yaml
+++ b/deployment/templates/wes/wes-deployment.yaml
@@ -28,6 +28,8 @@ spec:
         command: [ 'gunicorn' ]
         args: [ '--log-level', 'debug', '-c', 'config.py', 'wsgi:app' ]
         env:
+        - name: WES_CONFIG
+          value: /etc/app_config/app_config.yaml
         - name: MONGO_HOST
           value: {{ .Values.mongodb.appName }}
         - name: MONGO_PORT
@@ -78,14 +80,21 @@ spec:
         - mountPath: /tmp/user/.netrc
           subPath: .netrc
           name: wes-netrc-secret
+        - mountPath: /etc/app_config
+          name: app-config
       volumes:
       - name: wes-volume
         persistentVolumeClaim:
           claimName: {{ .Values.wes.appName }}-volume
+
       - name: wes-netrc-secret
         secret:
           secretName: netrc
           items:
           - key: netrc
             path: .netrc
+      - configMap:
+          defaultMode: 420
+          name: app-config
+        name: app-config
 

--- a/utils/generate_configuration_map.sh
+++ b/utils/generate_configuration_map.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+#
+# Script to create a configMap using the default YAML file for the
+# code.
+#
+####################################################################
+
+APP_CONFIG="$1"
+#
+CONFIG_MAP='deployment/templates/wes/app-config.json'
+
+#
+# See if we have the tool to manipulate JSON
+#
+command -v jq >/dev/null || {
+  echo;echo "ERROR: Command jq command not found. Please install it, or edit the configmap 'app-config' manualy with the changes you want to apply to app_config.yaml." >&2;
+  exit 2
+}
+#
+
+#
+# See if we have the tool to interact with the cluster
+#
+if command -v kubectl >/dev/null
+then
+  KUBECTL='kubectl'
+elif command -v oc >/dev/null
+then
+  KUBECTL='oc'
+else
+  echo;echo "ERROR: 'kubectl' nor 'oc' cannot be found. Please install any of them." >&2;
+  exit 3
+fi
+#
+
+#
+# See if the default configuration file exists
+#
+if [ -z "$APP_CONFIG" ];
+then
+  APP_CONFIG=cwl_wes/config/app_config.yaml
+fi
+
+if [ ! -f "$APP_CONFIG" -o ! -f "$CONFIG_MAP" ];
+then
+  test -f "$APP_CONFIG" || echo "App config file '$APP_CONFIG', not found." >&2
+  test -f "$CONFIG_MAP" || echo "Config ma definition '$CONFIG_MAP', not found." >&2
+  echo "Use: $0 <APP_CONFIG> [CONFIG_MAP_DEFINITION]" >&2
+  exit 1
+fi
+#
+
+
+jq ".data.\"app_config.yaml\" = \"$(cat $APP_CONFIG)\"" $CONFIG_MAP | $KUBECTL replace --force -f -
+


### PR DESCRIPTION

**Details**

As stated in #163, currently it is not possible to change the configuration without rebuilding the container. There is a variable called `WES_CONFIG` that allows to specify a secondary configuration file. Anything that is defined in the file pointed by `WES_CONFIG` with take precedence over the default configuration. Initially the config map is created empty, only with coments. Then the user can use the script `utils/generate_configuration_map.sh` to inject the current configuration in this repository, into the config map. 

**Documentation**

TODO

**Closing issues**

Closes #163
