### PR TITLE
ci: simplify build stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ jobs:
       name: Build, deploy, test and publish
       script:
         - mkdir -p ${DATA_DIR}/{db,output,tmp}  # create data directories
-        - docker build -t "${DOCKER_REPO_NAME}:${DOCKER_TAG}" .
         - docker-compose up -d --build
         - sleep 30  # wait for services to start up
         - |
@@ -44,10 +43,7 @@ jobs:
           ) == '200' || travis_terminate 1
         - docker-compose down
         - echo "${DOCKER_TOKEN}" | docker login -u "${DOCKER_USER}" --password-stdin
+        - docker tag "${DOCKER_REPO_NAME}:latest" "${DOCKER_REPO_NAME}:${DOCKER_TAG}"
         - docker push "${DOCKER_REPO_NAME}:${DOCKER_TAG}"
-        - |
-          if [ "$TRAVIS_BRANCH" = "dev" ]; then
-            docker tag "${DOCKER_REPO_NAME}:${DOCKER_TAG}" "${DOCKER_REPO_NAME}:latest"
-            docker push "${DOCKER_REPO_NAME}:latest"
-          fi
+        - if [ "$TRAVIS_BRANCH" = "dev" ]; then docker push "${DOCKER_REPO_NAME}:latest"; fi
         - rm ${HOME}/.docker/config.json  # delete token


### PR DESCRIPTION
The `build` stage of the CI pipeline was simplified and the pipeline should now take less time as the image is not built twice.