### PR TITLE
build: add .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# Ignore Git- and GitHub-specific files and dirs
+.git
+.github
+.gitignore
+
+# Remove all docs but README.md from root directory
+*.md
+!README*.md
+
+# Ignore build-specific files and dirs
+**/*.egg-info
+src
+
+# Ignore deployment-specific files and dirs
+docker-compose.yaml
+deployment
+utils
+
+# Ignore security-related files and dirs
+**/.netrc
+
+# Ignore CI-related files and dirs
+.travis.yml
+

--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,4 @@ tests/tmp/*
 tests/output/*
 *.modified.yaml
 .idea/*
+.netrc


### PR DESCRIPTION
- add `.dockerignore` file to remove the following files from the build context:
  - Git- & GitHub- specific files/dirs
  - build-, CI- & deployment-specific files/dirs
  - security-related files/dirs
  - docs other than `README.md`
- add `.netrc` to `.gitignore`