### PR TITLE
fix: remove duplicate entry from Helm charts 

### DIFF
--- a/deployment/templates/wes/wes-ingress.yaml
+++ b/deployment/templates/wes/wes-ingress.yaml
@@ -137,13 +137,6 @@ status: {}
 
 ---
 apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  name: {{ .Values.wes.appName }}-autoadmin
-
----
-apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.tlsSecret }}


### PR DESCRIPTION
Resolves #185 (Error: `serviceaccounts "cwlwes-autoadmin" already exists`)