### PR TITLE
Reload WES automatically when configMap changes

### DIFF
--- a/cwl_wes/config/app_config.yaml
+++ b/cwl_wes/config/app_config.yaml
@@ -1,4 +1,7 @@
 # General server/service settings
+#
+# Any change in this file will be detected by gunicorn and the configuration will be reloaded.
+#
 server:
     host: '0.0.0.0'
     port: 8080

--- a/deployment/templates/wes/app-config.yaml
+++ b/deployment/templates/wes/app-config.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  app_config.yaml: '# General server/service settings'
+  {{ .Values.extra_config.file }}: '# Empty, this configMap will be filled by Job (configmap-job-cwlwes)'
 kind: ConfigMap
 metadata:
   name: app-config

--- a/deployment/templates/wes/wes-deployment.yaml
+++ b/deployment/templates/wes/wes-deployment.yaml
@@ -26,10 +26,10 @@ spec:
         imagePullPolicy: Always
         workingDir: '/app/cwl_wes'
         command: [ 'gunicorn' ]
-        args: [ '--log-level', 'debug', '-c', 'config.py', 'wsgi:app' ]
+        args: [ '--log-level', 'debug', '-c', 'config.py', 'wsgi:app', '--reload', '--reload-extra-file', '{{ .Values.extra_config.folder }}/{{ .Values.extra_config.file }}' ]
         env:
         - name: WES_CONFIG
-          value: /etc/app_config/app_config.yaml
+          value: {{ .Values.extra_config.folder }}/{{ .Values.extra_config.file }}
         - name: MONGO_HOST
           value: {{ .Values.mongodb.appName }}
         - name: MONGO_PORT
@@ -80,7 +80,7 @@ spec:
         - mountPath: /tmp/user/.netrc
           subPath: .netrc
           name: wes-netrc-secret
-        - mountPath: /etc/app_config
+        - mountPath: {{ .Values.extra_config.folder}}
           name: app-config
       volumes:
       - name: wes-volume

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -7,6 +7,10 @@ clusterType: openshift  # either 'kubernetes' or 'openshift'
 tlsSecret: mytls-secret  # put name of tlsSecret
 storageAccessMode: ReadWriteOnce  # mongodb-pvc.yaml/rabbitmq-pvc.yaml, change to ReadWriteMany if storageClass can do RWX
 
+extra_config:
+  folder: /etc/app_config
+  file: app_config.yaml
+
 autocert:
   createJob: "true"  # actually create autocert cronjob, for K8S with autocert installed set to "false"
   schedule: "0 0 1 */2 *"  # cronjob schedule
@@ -23,9 +27,9 @@ flower:
 wes:
   appName: cwlwes
   image: elixircloud/cwl-wes:latest
-  netrcMachine: defaultmachine  # change this
-  netrcLogin: defaultnetrclogin  # change this
-  netrcPassword: defaultnetrcpassword  # change this
+  # netrcMachine: defaultmachine  # change this
+  # netrcLogin: defaultnetrclogin  # change this
+  # netrcPassword: defaultnetrcpassword  # change this
   storageClass: nfs-client  # <- wes-volume.yaml, only for K8S, a storageClass with readWriteMany capability is required
   volumeSize: 1Gi
 
@@ -62,5 +66,3 @@ ingress: # <- wes-ingress-kubernetes.yaml, only for system ingress for K8S, ensu
       ingressclass: "nginx"
       tlsacme: "\"true\""
       clusterissuer: "letsencrypt-prod"
-
-


### PR DESCRIPTION
**Details**
This is a solution to #190
WES will pick up automatically pick up changes in the config map. It uses the '--reload' and '--reload-extra-file' features of `gunicorn` to pick up changes in the Deployment.

**Closing issues**

closes #190