### PR TITLE
feat: improve logging in run request validation

### DIFF
--- a/cwl_wes/ga4gh/wes/endpoints/run_workflow.py
+++ b/cwl_wes/ga4gh/wes/endpoints/run_workflow.py
@@ -87,10 +87,11 @@ def __immutable_multi_dict_to_nested_dict(
 def __validate_run_workflow_request(data: Dict) -> None:
     """Validates presence and types of workflow run request form data; sets
     defaults for optional fields."""
+
     # The form data is not validated properly because all types except
     # 'workflow_attachment' are string and none are labeled as required
-    # Considering the 'RunRequest' model in the current specs (0.3.0), the
-    # following assumptions are made and verified for the indicated parameters:
+    # Considering the 'RunRequest' model in the specs, the following
+    # assumptions are made and verified for the indicated parameters:
     # workflow_params:
     #   type = dict
     #   required = True
@@ -113,8 +114,7 @@ def __validate_run_workflow_request(data: Dict) -> None:
     #   type = [str]
     #   required = False
 
-    # Set required parameters
-    required = {
+    params_required = {
         'workflow_params',
         'workflow_type',
         'workflow_type_version',
@@ -130,22 +130,29 @@ def __validate_run_workflow_request(data: Dict) -> None:
         'workflow_engine_parameters',
         'tags',
     ]
-    type_str = dict((key, data[key]) for key in params_str if key in data)
-    type_dict = dict((key, data[key]) for key in params_dict if key in data)
-    # TODO: implement type casting/checking for workflow attachment
 
     # Raise error if any required params are missing
-    if not required <= set(data):
-        logger.error('POST request does not conform to schema.')
-        raise BadRequest
+    invalid = False
+    for param in params_required:
+        if param not in data:
+            logger.error(f"Required parameter '{param}' not in request body.")
+            invalid = True
 
     # Raise error if any string params are not of type string
-    if not all(isinstance(value, str) for value in type_str.values()):
-        logger.error('POST request does not conform to schema.')
-        raise BadRequest
+    for param in params_str:
+        if param in data and not isinstance(data[param], str):
+            logger.error(f"Parameter '{param}' is not of string type.")
+            invalid = True
 
     # Raise error if any dict params are not of type dict
-    if not all(isinstance(value, dict) for value in type_dict.values()):
+    for param in params_dict:
+        if param in data and not isinstance(data[param], dict):
+            logger.error(
+                f"Parameter '{param}' is not of dictionary type. Invalid JSON?"
+            )
+            invalid = True
+
+    if invalid:
         logger.error('POST request does not conform to schema.')
         raise BadRequest
 
@@ -154,7 +161,7 @@ def __validate_run_workflow_request(data: Dict) -> None:
 
 def __check_service_info_compatibility(data: Dict) -> None:
     """Checks compatibility with service info; raises BadRequest."""
-    # TODO: implement me
+    # TODO: implement
     return None
 
 
@@ -285,6 +292,8 @@ def __create_run_environment(
         use_http=use_http,
     )
 
+    logger.warning("ALL GOOD")
+    raise BadRequest
     return document
 
 


### PR DESCRIPTION
* log missing required parameters or parameters of the wrong type explicitly when validating the run request
* all failed validations are logged before a `BadRequest` response is returned