### PR TITLE
fix: support array outputs

### DIFF
--- a/cwl_wes/tasks/celery_task_monitor.py
+++ b/cwl_wes/tasks/celery_task_monitor.py
@@ -487,7 +487,7 @@ class TaskMonitor():
         """Parses outputs from cwl-tes log."""
         # Find outputs object in log string
         re_outputs = re.compile(
-            r'(^\{$\n^ {4}"\S+": \{$\n(^ {4,}.*$\n)*^ {4}\}$\n^\}$\n)',
+            r'(^\{$\n^ {4}"\S+": [\[\{]$\n(^ {4,}.*$\n)*^ {4}[\]\}]$\n^\}$\n)',
             re.MULTILINE
         )
         m = re_outputs.search(log)


### PR DESCRIPTION
**Details**

If the workflow contains one or more outputs of array type then WES does not match the patter in the cwl-TES logs and the output list returned is empty (Issue #206).

**Documentation**

The regular expression pattern that recognizes outputs in the cwl-TES log was changed to recognize brackets as well as curly brackets. This covers all cases when the outputs contain one or more values. This is a quick and dirty solution, until something more appropriate is implemented.

**Closing issues**

closes #206 

**Credit**
[Kostis Zagganas ](https://github.com/zagganas)