### PR TITLE
build: redirect base route to Swagger UI

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -130,3 +130,4 @@ See [`values.yaml`](values.yaml) for default values.
 | wes.netrcPassword | string | password for accessing the sFTP server |
 | wes.storageClass | string | type of storageClass for WES, must have RWX capability |
 | wes.volumeSize | string | size of volume reserved for the main application |
+| wes.redirect | boolean | Activate/deactivate the '/' to '/ga4gh/wes/v1/ui/' redirection |

--- a/deployment/templates/wes/wes-redirect.yaml
+++ b/deployment/templates/wes/wes-redirect.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Values.wes.redirect true }}
+{{ if and (eq .Values.wes.redirect true) (eq .Values.clusterType "openshift") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -97,7 +97,6 @@ status:
 
 ---
 
-{{ if eq .Values.clusterType "openshift" }}
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
@@ -117,6 +116,5 @@ spec:
   wildcardPolicy: None
 status:
   ingress: []
-{{ end }}
 
 {{ end }}

--- a/deployment/templates/wes/wes-redirect.yaml
+++ b/deployment/templates/wes/wes-redirect.yaml
@@ -1,0 +1,122 @@
+{{ if eq .Values.wes.redirect true }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: nginx-redirect
+  name: nginx-redirect
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx-redirect
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: nginx-redirect
+    spec:
+      containers:
+      - image: lvarin/nginx-okd:latest
+        imagePullPolicy: Always
+        name: nginx-redirect
+        ports:
+        - containerPort: 8081
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/nginx/conf.d/
+          name: nginx-redirect
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: nginx-redirect
+        name: nginx-redirect
+status: {}
+
+---
+
+apiVersion: v1
+data:
+  default.conf: |-
+    server {
+        listen 8081;
+        server_name  localhost;
+
+        rewrite ^/$ /ga4gh/wes/v1/ui/  permanent;
+        port_in_redirect off;
+
+        location / {
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+        }
+
+        # redirect server error pages to the static page /50x.html
+        #
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   /usr/share/nginx/html;
+        }
+
+    }
+kind: ConfigMap
+metadata:
+  name: nginx-redirect
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: nginx-redirect
+  name: nginx-redirect
+spec:
+  ports:
+  - name: 8081-tcp
+    port: 8081
+    protocol: TCP
+    targetPort: 8081
+  selector:
+    app: nginx-redirect
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}
+
+---
+
+{{ if eq .Values.clusterType "openshift" }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: nginx-redirect
+spec:
+  host: {{ .Values.wes.appName }}.{{ .Values.applicationDomain }}
+  path: /
+  port:
+    targetPort: 8081-tcp
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name: nginx-redirect
+    weight: 100
+  wildcardPolicy: None
+status:
+  ingress: []
+{{ end }}
+
+{{ end }}

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -33,6 +33,8 @@ wes:
   #  Password: defaultnetrcpassword
   storageClass: nfs-client  # <- wes-volume.yaml, only for K8S, a storageClass with readWriteMany capability is required
   volumeSize: 1Gi
+  redirect: true
+  # Activate/deactivate the '/' to '/ga4gh/wes/v1/ui/' redirection
 
 celeryWorker:
   appName: celery-worker

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -33,7 +33,7 @@ wes:
   #  Password: defaultnetrcpassword
   storageClass: nfs-client  # <- wes-volume.yaml, only for K8S, a storageClass with readWriteMany capability is required
   volumeSize: 1Gi
-  redirect: true
+  redirect: false
   # Activate/deactivate the '/' to '/ga4gh/wes/v1/ui/' redirection
 
 celeryWorker:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 attrs==18.2.0
-bson==0.5.10
 celery==4.1.1
 connexion==1.5.2
 cryptography==3.2
@@ -16,7 +15,7 @@ kombu==4.2.1
 py-tes==0.3.0
 pydantic
 PyJWT==1.6.4
-pymongo==3.7.1
+pymongo==3.7.2
 python-dateutil==2.6.1
 PyYAML==5.3
 requests==2.20.0


### PR DESCRIPTION
**Details**

Create Nginx with configmap attached, as well as the corresponding service and route, to optionally redirect base route `/` to `/g4agh/wes/v1/ui/` for OpenShift deployments.

**Documentation**

Add new parameter to activate redirection (deactivated by default).

**Closing issues**

Fixes #211
