### PR TITLE
fix: retain configmap upon Helm upgrade

### DIFF
--- a/deployment/config/app_config.yaml
+++ b/deployment/config/app_config.yaml
@@ -1,1 +1,0 @@
-../../cwl_wes/config/app_config.yaml

--- a/deployment/config/app_config.yaml
+++ b/deployment/config/app_config.yaml
@@ -1,0 +1,1 @@
+../../cwl_wes/config/app_config.yaml

--- a/deployment/templates/wes/app-config.yaml
+++ b/deployment/templates/wes/app-config.yaml
@@ -1,6 +1,11 @@
+{{- $appconfig := "# Empty, this configMap will be filled by Job (configmap-job-cwlwes)" }}
+{{- $config_map := (lookup "v1" "ConfigMap" .Release.Namespace "app-config") }}
+{{- if $config_map }}
+  {{- $appconfig = index $config_map.data "app_config.yaml" }}
+{{- end }}
 apiVersion: v1
 data:
-{{ (.Files.Glob "config/*").AsConfig | indent 2 }}
+  app_config.yaml: {{ $appconfig | quote }}
 kind: ConfigMap
 metadata:
   name: app-config

--- a/deployment/templates/wes/app-config.yaml
+++ b/deployment/templates/wes/app-config.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  {{ .Values.extra_config.file }}: '# Empty, this configMap will be filled by Job (configmap-job-cwlwes)'
+{{ (.Files.Glob "config/*").AsConfig | indent 2 }}
 kind: ConfigMap
 metadata:
   name: app-config

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 attrs==18.2.0
-bson==0.5.10
 celery==4.1.1
 connexion==1.5.2
 cryptography==3.2
@@ -16,7 +15,7 @@ kombu==4.2.1
 py-tes==0.3.0
 pydantic
 PyJWT==1.6.4
-pymongo==3.7.1
+pymongo==3.7.2
 python-dateutil==2.6.1
 PyYAML==5.3
 requests==2.20.0


### PR DESCRIPTION
**Details**

Fix #214 by using `lookup` to check the current version; if none is found, the default configmap job is used.

**Closing issues**

Closes #214
