### PR TITLE
build: remove conflicting dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 attrs==18.2.0
-bson==0.5.10
+#bson==0.5.10
 celery==4.1.1
 connexion==1.5.2
 cryptography==3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 attrs==18.2.0
-#bson==0.5.10
 celery==4.1.1
 connexion==1.5.2
 cryptography==3.2


### PR DESCRIPTION
Conflicts between pinned `bson` and `pymongo` versions caused `abc`-importing issue, preventing the service from starting.
See #217 for more details.