### PR TITLE
Bumped ingress to new specs for k8s 1.22

### DIFF
--- a/deployment/templates/flower/flower-ingress.yaml
+++ b/deployment/templates/flower/flower-ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 {{ end }}
 metadata:
@@ -32,7 +32,10 @@ status:
     http:
       paths:
       - path: "/"
+        pathType: Prefix
         backend:
-          serviceName: {{ .Values.flower.appName }}
-          servicePort: 5555
+          service:
+            name: {{ .Values.flower.appName }}
+            port: 
+              number: 5555
 {{ end }}

--- a/deployment/templates/wes/celery-deployment.yaml
+++ b/deployment/templates/wes/celery-deployment.yaml
@@ -60,6 +60,10 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: wes-volume
+        {{ if ne .Values.celeryWorker.tmpVolumeSize "0Gi" }} 
+        - mountPath: /tmp
+          name: celery-tmp-volume
+        {{ end }}
         - mountPath: /tmp/user/.netrc
           subPath: .netrc
           name: wes-netrc-secret
@@ -67,6 +71,11 @@ spec:
       - name: wes-volume
         persistentVolumeClaim:
           claimName: {{ .Values.wes.appName }}-volume
+      {{ if ne .Values.celeryWorker.tmpVolumeSize "0Gi" }} 
+      - name: celery-tmp-volume
+        persistentVolumeClaim:
+          claimName: celery-tmp-volume
+      {{ end }} 
       - name: wes-netrc-secret
         secret:
           secretName: netrc

--- a/deployment/templates/wes/celery-tmp-cleaner.yaml
+++ b/deployment/templates/wes/celery-tmp-cleaner.yaml
@@ -1,5 +1,9 @@
 {{ if .Values.celeryWorker.tmpCleaner }}
+{{ if ne .Values.clusterType "kubernetes" }}
+apiVersion: batch/v1beta1
+{{ else }}
 apiVersion: batch/v1
+{{ end }}
 kind: CronJob
 metadata:
   name: celery-tmp-cleaner

--- a/deployment/templates/wes/celery-tmp-cleaner.yaml
+++ b/deployment/templates/wes/celery-tmp-cleaner.yaml
@@ -1,0 +1,29 @@
+{{ if .Values.celeryWorker.tmpCleaner }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: celery-tmp-cleaner
+spec:
+  schedule: "@hourly"
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: demo-clean
+            image: busybox
+            args:
+            - /bin/sh
+            - -c
+            - find /tmp -maxdepth 1 -type f -mmin +60  -exec rm -f {} \; 
+            volumeMounts:
+            - name: celery-tmp-volume
+              mountPath: "/tmp"
+          restartPolicy: OnFailure
+          volumes:
+          - name: celery-tmp-volume
+            persistentVolumeClaim:
+              claimName: celery-tmp
+{{ end }}

--- a/deployment/templates/wes/celery-tmp-volume.yaml
+++ b/deployment/templates/wes/celery-tmp-volume.yaml
@@ -1,0 +1,17 @@
+---
+{{ if ne .Values.celeryWorker.tmpVolumeSize "0Gi" }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: celery-tmp-volume
+  {{ if eq .Values.clusterType "kubernetes" }}
+  annotations:
+    volume.beta.kubernetes.io/storage-class: {{ .Values.wes.storageClass }}
+  {{ end }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.celeryWorker.tmpVolumeSize }}
+{{ end }}

--- a/deployment/templates/wes/wes-ingress-kubernetes.yaml
+++ b/deployment/templates/wes/wes-ingress-kubernetes.yaml
@@ -1,6 +1,6 @@
 {{ if eq .Values.clusterType "kubernetes" }}
 {{ if .Values.ingress.letsencryptSystem }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: wes-ingress-kubernetes {{ if .Values.ingress.tls_letsencrypt }}
@@ -19,11 +19,14 @@ spec: {{ if .Values.tlsSecret }}
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: {{ .Values.wes.appName }}
-              servicePort: 8080
+              service:
+                name: {{ .Values.wes.appName }}
+                port: 
+                  number: 8080
 {{ else }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Values.wes.appName }}
@@ -35,13 +38,17 @@ spec:
     http:
       paths:
       - path: "/.well-known"
+        pathType: Prefix
         backend:
-          serviceName: {{ .Values.wes.appName }}-certbot
-          servicePort: 8080
+          service:
+            name: {{ .Values.wes.appName }}-certbot
+            port: 8080
       - path: "/ga4gh/wes/v1"
+        pathType: Prefix
         backend:
-          serviceName: {{ .Values.wes.appName }}
-          servicePort: 8080
+          service:
+            name: {{ .Values.wes.appName }}
+            port: 8080
   {{ if ne .Values.tlsSecret "" }}
   tls:
   - secretName: {{ .Values.tlsSecret }}

--- a/deployment/templates/wes/wes-ingress.yaml
+++ b/deployment/templates/wes/wes-ingress.yaml
@@ -58,7 +58,11 @@ status:
   loadBalancer: {}
 
 ---
+{{ if ne .Values.clusterType "kubernetes" }}
+apiVersion: batch/v1beta1
+{{ else }}
 apiVersion: batch/v1
+{{ end }}
 kind: CronJob
 metadata:
   name: {{ .Values.wes.appName }}-certbot

--- a/deployment/templates/wes/wes-ingress.yaml
+++ b/deployment/templates/wes/wes-ingress.yaml
@@ -58,7 +58,7 @@ status:
   loadBalancer: {}
 
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Values.wes.appName }}-certbot

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -39,6 +39,8 @@ wes:
 celeryWorker:
   appName: celery-worker
   image: elixircloud/cwl-wes:latest
+  tmpVolumeSize: 0Gi # Volume size for the /tmp directory. Leave 0 to not deploy. StorageClass with readWriteMany capability is required
+  tmpCleaner: false # If tmpVolume is deployed, then it should be cleaned hourly.
 
 mongodb:
   appName: mongodb


### PR DESCRIPTION
**Details**
K8s API endpoint currently used in the helm chart templates will be removed in the next version(1.21) and the deployment will break. I have bumped the specifications to the current version of k8s (1.21) which will be compatible with the next version. Added an option to deploy a pvc for the /tmp directory of the Celery pods, so that they do not run out of disk space while moving files around.
Closes #220 
Closes #222 