### PR TITLE
Fix CI build

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,7 +45,7 @@ services:
       - "27017:27017"
 
   flower:
-    image: mher/flower:0.9
+    image: mher/flower:0.9.7
     restart: unless-stopped
     links:
       - wes-worker


### PR DESCRIPTION
The build fails because the image mher/flower:0.9 does not exist (anymore?). But mher/flower:0.9.7 exists.

**Details**

docker compose fails, because it cannot find an image.

**Testing**

This fixes the tests

**Closing issues**

This closes #223 

**Credit**

Add your credentials to the [list of contributors](contributors.md) once your pull request was merged.
