### PR TITLE
Fixed the celery tmp PVC in the cleaner cronjob

### DIFF
--- a/deployment/templates/wes/celery-tmp-cleaner.yaml
+++ b/deployment/templates/wes/celery-tmp-cleaner.yaml
@@ -29,5 +29,5 @@ spec:
           volumes:
           - name: celery-tmp-volume
             persistentVolumeClaim:
-              claimName: celery-tmp
+              claimName: celery-tmp-volume
 {{ end }}


### PR DESCRIPTION
In my previous pull request there was an error in the celery tmp PVC name in the cronjob definition. This PR fixes that.