### PR TITLE
Add option to specify app-config contents in values file

### DIFF
--- a/deployment/templates/wes/app-config.yaml
+++ b/deployment/templates/wes/app-config.yaml
@@ -1,11 +1,6 @@
-{{- $appconfig := "# Empty, this configMap will be filled by Job (configmap-job-cwlwes)" }}
-{{- $config_map := (lookup "v1" "ConfigMap" .Release.Namespace "app-config") }}
-{{- if $config_map }}
-  {{- $appconfig = index $config_map.data "app_config.yaml" }}
-{{- end }}
 apiVersion: v1
 data:
-  app_config.yaml: {{ $appconfig | quote }}
+  app_config.yaml: {{ .Values.wes.appConfig | quote }}
 kind: ConfigMap
 metadata:
   name: app-config

--- a/deployment/templates/wes/wes-configmap.yaml
+++ b/deployment/templates/wes/wes-configmap.yaml
@@ -1,4 +1,4 @@
----
+{{- if .Values.wes.configWithJob }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -23,4 +23,4 @@ spec:
       restartPolicy: Never
       serviceAccountName: {{ .Values.wes.appName }}-autoadmin
 status: {}
-
+{{- end }}

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -34,6 +34,119 @@ wes:
   storageClass: nfs-client  # <- wes-volume.yaml, only for K8S, a storageClass with readWriteMany capability is required
   volumeSize: 1Gi
   redirect: false
+  configWithJob: false
+  appConfig: |
+    # General server/service settings
+    #
+    # Any change in this file will be detected by gunicorn and the configuration will be reloaded.
+    #
+    server:
+        host: '0.0.0.0'
+        port: 8080
+        debug: True
+        environment: development
+        testing: False
+        use_reloader: True
+
+    # Security settings
+    security:
+        authorization_required: False
+        jwt:
+            add_key_to_claims: True
+            algorithms:
+              - RS256
+            allow_expired: False
+            audience: null  # list of allowed audiences or 'null' (do not validate audience)
+            claim_identity: sub
+            claim_issuer: iss
+            claim_key_id: kid
+            header_name: Authorization
+            token_prefix: Bearer
+            validation_methods:
+              - userinfo
+              - public_key
+            validation_checks: all  # 'any' or 'all'
+
+    # Database settings
+    database:
+        host: mongodb
+        port: 27017
+        name: cwl-wes-db
+        run_id:
+            length: 6
+            charset: string.ascii_uppercase + string.digits
+
+    # Storage
+    storage:
+        permanent_dir: '/data/output'
+        tmp_dir: '/data/tmp'
+        remote_storage_url: 'ftp://ftp-private.ebi.ac.uk/upload/foivos'
+
+    # Celery task queue
+    celery:
+        broker_host: rabbitmq
+        broker_port: 5672
+        result_backend: 'rpc://'
+        include:
+            - cwl_wes.tasks.tasks.run_workflow
+            - cwl_wes.tasks.tasks.cancel_run
+        monitor:
+            timeout: 0.1
+        message_maxsize: 16777216
+
+    # OpenAPI specs
+    api:
+        specs:
+            - path: '20181010.be85140.workflow_execution_service.swagger.yaml'
+              strict_validation: True
+              validate_responses: True
+              swagger_ui: True
+              swagger_json: True
+        endpoint_params:
+            default_page_size: 5
+            timeout_cancel_run: 60
+            timeout_run_workflow: Null
+
+    # WES service info settings
+    service_info:
+        contact_info: 'https://github.com/elixir-cloud-aai/cwl-WES'
+        auth_instructions_url: 'https://www.elixir-europe.org/services/compute/aai'
+        supported_filesystem_protocols:
+            - ftp
+            - https
+            - local
+        supported_wes_versions:
+            - 1.0.0
+        workflow_type_versions:
+            CWL:
+                workflow_type_version:
+                    - v1.0
+        workflow_engine_versions:
+            cwl-tes: 0.2.0
+        default_workflow_engine_parameters:
+            - type: string
+              default_value: some_string
+            - type: int
+              default_value: '5'
+        tags:
+            known_tes_endpoints: 'https://tes.tsi.ebi.ac.uk/|https://tes-dev.tsi.ebi.ac.uk/|https://csc-tesk.c03.k8s-popup.csc.fi/|https://tesk.c01.k8s-popup.csc.fi/'
+            app_version: 0.15.0
+
+    # TES server
+    tes:
+        url: 'https://csc-tesk.c03.k8s-popup.csc.fi/'
+        timeout: 5
+        status_query_params: 'FULL'
+
+    # DRS integration
+    drs:
+        port: Null  # use this port for resolving DRS URIs; set to `Null` to use default (443)
+        base_path: Null  # use this base path for resolving DRS URIs; set to `Null` to use default (`ga4gh/drs/v1`)
+        use_http: False  # use `http` for resolving DRS URIs; set to `False` to use default (`https`)
+        file_types:  # extensions of files to scan for DRS URI resolution
+            - cwl
+            - yaml
+            - yml
   # Activate/deactivate the '/' to '/ga4gh/wes/v1/ui/' redirection
 
 celeryWorker:


### PR DESCRIPTION
**Details**

I have added option to specify app-config.yaml contents in the values file for helm. This PR addresses issue #238
I have also kept the option to use a job to populate the config map contents in case it is necessary for certain workflows.

**Documentation**

`appConfig` value contains the contents of the `app-config.yaml` file

`configWithJob` value says whether the config map should be populated with a job (as it was until now), this option is set to false by default