### PR TITLE
Added curl test for PR and before building

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,14 +3,32 @@ name: Docker Image CI
 on:
   push:
     branches: [ dev ]
-  pull_request:
-    branches: [ dev ]
+  # pull_request:
+  #   branches: [ dev ]
 
 env:
   DOCKER_REPO_NAME: elixircloud/cwl-wes
 
 jobs:
-
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Test build
+        run: docker-compose up -d
+      - name: Sleep
+        shell: bash
+        run: sleep 30;
+      - name: Test endpoint
+        shell: bash
+        run: bash test-call.bash
+      - name: End test
+        run: docker-compose down
+  
   build:
 
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,8 +3,6 @@ name: Docker Image CI
 on:
   push:
     branches: [ dev ]
-  # pull_request:
-  #   branches: [ dev ]
 
 env:
   DOCKER_REPO_NAME: elixircloud/cwl-wes
@@ -25,10 +23,10 @@ jobs:
         run: sleep 30;
       - name: Test endpoint
         shell: bash
-        run: bash test-call.bash
+        run: bash test-http-call.bash
       - name: End test
         run: docker-compose down
-  
+
   build:
 
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -25,6 +25,6 @@ jobs:
         run: sleep 30;
       - name: Test endpoint
         shell: bash
-        run: bash test-call.bash
+        run: bash test-http-call.bash
       - name: End test
         run: docker-compose down

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -1,0 +1,30 @@
+name: Test
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation. 
+
+on:
+  pull_request:
+    branches: [ dev ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Test build
+        run: docker-compose up -d
+      - name: Sleep
+        shell: bash
+        run: sleep 30;
+      - name: Test endpoint
+        shell: bash
+        run: bash test-call.bash
+      - name: End test
+        run: docker-compose down

--- a/test-http-call.bash
+++ b/test-http-call.bash
@@ -1,0 +1,5 @@
+CODE=$(curl --write-out '%{http_code}' --output /dev/null --silent localhost:8080/ga4gh/wes/v1/runs
+if [ $CODE != "200" ]
+then
+  exit 1;
+fi

--- a/test-http-call.bash
+++ b/test-http-call.bash
@@ -1,4 +1,4 @@
-CODE=$(curl --write-out '%{http_code}' --output /dev/null --silent localhost:8080/ga4gh/wes/v1/runs
+CODE=$(curl --write-out '%{http_code}' --output /dev/null --silent localhost:8080/ga4gh/wes/v1/runs)
 if [ $CODE != "200" ]
 then
   exit 1;


### PR DESCRIPTION
**Details**

Currently, there are no code tests for PRs and before building the Docker image. This PR adds a curl test like the one that used to exist when TravisCI was used.

**Testing**

Tried the workflows and it seems that they are currently failing because there is an error with current libraries.

**Closing issues**

Closes #244.
