### PR TITLE
Update imagePullPolicy...

### DIFF
--- a/deployment/Chart.yaml
+++ b/deployment/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cwlwes
 description: A cwl-WES Helm chart for Kubernetes.
 type: application
-version: 2.0.0
-appVersion: 2.0.0
+version: 2.0.1
+appVersion: 2.0.1

--- a/deployment/templates/mongodb/mongodb-deployment.yaml
+++ b/deployment/templates/mongodb/mongodb-deployment.yaml
@@ -54,7 +54,7 @@ spec:
                 key: databasePassword
                 name: {{ .Values.mongodb.appName }}
           image: {{ .Values.mongodb.image }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.mongodb.pullPolicy | quote }}
           livenessProbe:
             failureThreshold: 3
             initialDelaySeconds: 30

--- a/deployment/templates/mongodb/mongodb-deployment.yaml
+++ b/deployment/templates/mongodb/mongodb-deployment.yaml
@@ -54,7 +54,7 @@ spec:
                 key: databasePassword
                 name: {{ .Values.mongodb.appName }}
           image: {{ .Values.mongodb.image }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 3
             initialDelaySeconds: 30

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -164,7 +164,7 @@ wes:
 
 celeryWorker:
   appName: celery-worker
-  image: elixircloud/cwl-wes:latest
+  image: lvarin/cwl-wes:20220325
   initResources:
     limits:
       memory: 16Mi


### PR DESCRIPTION
...to pull latest mongo:noble version (v8.2.3) and fix cve-2025-14847

**IMPORTANT: Please create an issue before filing a pull request! Changes need to be discussed before proceeding. Please read the [contribution guidelines](CONTRIBUTING.md).**

**Details**

Please provide enough information so that others can review your pull request. Give a brief summary of the motivation. Refer to the corresponding issue/s with `#XXXX` for more information.

**Testing**

Write the appropriate unit and integration tests, if applicable. Make sure these and all other tests pass.

**Documentation**

Please document your changes and test cases in the appropriate places, if applicable.

**Style**

Make sure your changes adhere to the coding/documentation style used throughout the project.

**Closing issues**

If your changes fix any issue/s, put `closes #XXXX` in your comment to auto-close it/them.

**Credit**

Add your credentials to the [list of contributors](contributors.md) once your pull request was merged.

## Summary by Sourcery

Bump the Helm chart and application versions and adjust deployment settings for MongoDB and the Celery worker image.

Enhancements:
- Update Helm chart and application versions from 2.0.0 to 2.0.1.
- Change MongoDB deployment to always pull the container image on pod startup.
- Switch the Celery worker image to use a specific tagged image instead of the previous default.